### PR TITLE
Style 3: Support Logo size parameter

### DIFF
--- a/common/css/style-source.css
+++ b/common/css/style-source.css
@@ -984,19 +984,23 @@ body {
 
 /*****Style 3*****/
 
-.style-3 > .logo img{
-	max-height: 4.5em;
-	max-width: 4.5em;
-}
-
 .style-3 > .logo {
     z-index: 1;
     margin: 0;
+    position: absolute;
+    width: 8.5em;
 }
-.style-3 > .logo.no-logo {
-	min-width: 5.5em;
-	min-height: 5.5em;
+.style-3.left > .logo {
+    left: -1.5em;
 }
+.style-3.right > .logo {
+    right: -1.5em;
+}
+
+.style-3 > .logo img {
+    margin: auto;
+}
+
 
 .style-3 > .graph-1 {
 	border-radius: 50%;
@@ -1006,18 +1010,7 @@ body {
 	z-index: 0;
 	box-sizing: border-box;
 }
-.style-3.left > .graph-1 {
-	margin-left: -5em;
-}
-.style-3.left > .logo.no-logo + .graph-1 {
-	margin-left: -6em;
-}
-.style-3.right > .graph-1 {
-	margin-right: -5em;
-}
-.style-3.right > .logo.no-logo + .graph-1 {
-	margin-right: -6em;
-}
+
 
 #lower-third-1.style-3 > .graph-1 {
     background: var(--alt-1-style-color-1);
@@ -1114,15 +1107,15 @@ body {
 }
 
 .style-3.left > .text-content {
-	/* margin-right: 0.5em; */
+	margin-right: 0.5em;
 	/* margin: 1em 2.5em 1em 0; FOR MULTI LINES */
-	left: 0.75em;
+	left: 1.25em;
 	position: relative;
 }
 .style-3.right > .text-content {
-	/* margin-left: 0.5em; */
+	margin-left: 0.5em;
 		/* margin: 1em 0 1em 2.5em; FOR MULTI LINES */
-	right: 0.75em;
+	right: 1.25em;
 	position: relative;
 }
 

--- a/lower thirds/control-panel.html
+++ b/lower thirds/control-panel.html
@@ -2559,7 +2559,7 @@
 							$("#alt-1-align-left").prop('checked', true).change();
 						}
 						document.getElementById("alt-1-logo").disabled = false;
-						document.getElementById("alt-1-logo-size").disabled = true;
+						document.getElementById("alt-1-logo-size").disabled = false;
 						$("#alt-1-style-border-color-appearance > :nth-child(3)").removeClass("disabled");
 						// $("#alt-1-background").prop('checked', true).change(); NO
 						// $("#alt-1-background").prop('checked', true);
@@ -2594,7 +2594,7 @@
 							$("#alt-2-align-left").prop('checked', true).change();
 						}
 						document.getElementById("alt-2-logo").disabled = false;
-						document.getElementById("alt-2-logo-size").disabled = true;
+						document.getElementById("alt-2-logo-size").disabled = false;
 						$("#alt-2-style-border-color-appearance > :nth-child(3)").removeClass("disabled");
 						break;
 				}
@@ -2625,7 +2625,7 @@
 							$("#alt-3-align-left").prop('checked', true).change();
 						}
 						document.getElementById("alt-3-logo").disabled = false;
-						document.getElementById("alt-3-logo-size").disabled = true;
+						document.getElementById("alt-3-logo-size").disabled = false;
 						$("#alt-3-style-border-color-appearance > :nth-child(3)").removeClass("disabled");
 						break;
 				}
@@ -2656,7 +2656,7 @@
 							$("#alt-4-align-left").prop('checked', true).change();
 						}
 						document.getElementById("alt-4-logo").disabled = false;
-						document.getElementById("alt-4-logo-size").disabled = true;
+						document.getElementById("alt-4-logo-size").disabled = false;
 						$("#alt-4-style-border-color-appearance > :nth-child(3)").removeClass("disabled");
 						break;
 				}				


### PR DESCRIPTION
## Support Logo Size parameter in Style 3

The size of the logo can now changed in style 3; exactly like in the other styles.

This is especially useful if you eg. want the logo to completely replace of the left box:
Here the logo scale is set to `10` and the box is made transparent:

![grafik](https://user-images.githubusercontent.com/7558512/236914601-60a79bad-933e-489d-ba2c-a269bf17cb7c.png)
![grafik](https://user-images.githubusercontent.com/7558512/236914525-54d9bf8e-199e-4685-9002-d67f99ffcde9.png)

The rest should have mostly stayed identical.
Margins have moved a little bit, but I made sure it still works for both left and right and also without image
![left](https://user-images.githubusercontent.com/7558512/236916168-b6c80982-3106-4fec-a0df-b784abc8959a.gif)
